### PR TITLE
Allow a wider range of Node engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,5 +16,5 @@
     "url": "git://github.com/johnhenry/valid-email.git"
   },
   "main": "index",
-  "engines": { "node": "^0.8.x" }
+  "engines": { "node": ">=0.8" }
 }


### PR DESCRIPTION
This fixes #2. Current valid-email provides warnings when installed in recent versions of Node, and fails to install completely with [Yarn](https://yarnpkg.org), even though it works perfectly in newer Node versions. Merging this and pushing a new release would make those problems all go away.