### PR TITLE
fix(): include lib/ in published npm package files

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "url": "git://github.com/johnhenry/valid-email.git"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "lib/"
   ],
   "scripts": {},
   "keywords": [


### PR DESCRIPTION
This fixes #8  

The "files" property in package.json specifies which files are published with the npm package. `index.js` requires `lib/` but `lib/` was not published with the package. This fix adds `lib/` to the published package.